### PR TITLE
Fetch Missions data from API

### DIFF
--- a/src/pages/Missions.js
+++ b/src/pages/Missions.js
@@ -1,7 +1,17 @@
-import React from 'react';
+import { React, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { FetchMissionsHandler } from '../redux/missions/missions';
 
-const Missions = () => (
-  <div>Missions</div>
-);
+const Missions = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(FetchMissionsHandler());
+  }, []);
 
+  return (
+    <div>
+      <h1>Missions</h1>
+    </div>
+  );
+};
 export default Missions;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,12 +1,26 @@
-const hello = 'hello';
+import axios from 'axios';
+
+const FETCH_MISSIONS = 'FETCH_MISSIONS';
 const missions = [];
+
+export const FetchMissionsHandler = () => async (dispatch) => {
+  const response = await axios.get('https://api.spacexdata.com/v3/missions');
+  return dispatch({ type: FETCH_MISSIONS, payload: response.data });
+};
+
 const missionsReducer = (state = missions, action) => {
   switch (action.type) {
-    case hello:
-      return [
-        ...state, 'hello',
-      ];
-    default: return state;
+    case FETCH_MISSIONS:
+      return action.payload.map((mission) => (
+        {
+          mission_id: mission.mission_id,
+          mission_name: mission.mission_name,
+          description: mission.description,
+          active: false,
+        }));
+
+    default:
+      return state;
   }
 };
 export default missionsReducer;


### PR DESCRIPTION
### In this PR I did the following:

- Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

- Once the data are fetched, dispatch an action to store the selected data in the Redux store:
mission_id
mission_name
description